### PR TITLE
Add callback_url option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Unreleased
+* add `callback_url` option ([https://docraptor.com/documentation/api#api_callback_url](https://docraptor.com/documentation/api#api_callback_url))
+
 ### 0.0.4 [May 23, 2016]
 * Don't use bundler to load gems during execution
 * Use short binary name when showing help

--- a/README.md
+++ b/README.md
@@ -54,6 +54,38 @@ We have guides for doing some of the common things:
 * [CSS Media Selector](https://docraptor.com/documentation/api#api_basic_pdf) to make the page look exactly as it does in your browser
 * Protect content with [HTTP authentication](https://docraptor.com/documentation/api#api_http_user) or [proxies](https://docraptor.com/documentation/api#api_http_proxy) so only DocRaptor can access them
 
+## Testing Callbacks
+
+The `--callback-url` option can be used to set a URL that will receive a POST request after your document has successfully been processed. You can simulate this in your *nix development environment using a couple of simple tools: [`nc`](http://linux.die.net/man/1/nc) and [`ngrok`](https://ngrok.com/).
+
+Let's say you had some document content in a file named `test.html`. To test the callback URL, start a new console and type:
+
+```
+nc -lk 9001
+```
+
+This will listen on port `9001` for requests. Now open another console and type in:
+```
+ngrok http 9001
+```
+
+This will setup an external URL that port forwards to port `9001` on your computer (conveniently being listened to by `nc`). Note the ngrok http URL. It should look something like `http://87654321.ngrok.io`. Copy that URL and open a third console where we will generate our document:
+```
+bin/docraptor test.html --async --callback_url "http://87654321.ngrok.io"
+```
+
+After the document has been generated, if we go to our console running `nc`, we should see we got an HTTP POST request that looks something like this:
+
+```
+POST / HTTP/1.1
+Connection: close
+Host: d94c779c.ngrok.io
+Content-Length: 139
+Content-Type: application/x-www-form-urlencoded
+X-Forwarded-For: 54.158.114.123
+
+download_url=https%3A%2F%2Fdocraptor.com%2Fdownload%2Fe4eabaca-f811-49f8-9375-fcb9cdeae5aa&download_id=e4eabaca-f811-49f8-9375-fcb9cdeae5aa
+```
 
 ## More Help
 

--- a/bin/docraptor
+++ b/bin/docraptor
@@ -53,6 +53,14 @@ opt_parser = OptionParser.new do |opts|
     options[:async] = async
   end
 
+  opts.on("--callback_url url", "Set a callback URL to be notified upon success. Defaults to naught") do |callback_url|
+    # callback_url can be used for local testing. You need three consoles:
+    #   nc -lk 9001                                                       # listen on port 9001 for any data
+    #   ngrok http 9001                                                   # setup external URL; port from nc session
+    #   bin/docraptor content --callback_url "http://1111111111.ngrok.io" # copied url from the ngrok session
+    options[:callback_url] = callback_url
+  end
+
   opts.on("-d", "--debug", "Enable debug logging.") do
     options[:debug] = true
   end
@@ -235,6 +243,8 @@ all_doc_attributes = {
   async:                  options[:async],
   ignore_resource_errors: options[:ignore_resource_errors],
 }
+
+all_doc_attributes[:callback_url] = options[:callback_url] if options[:callback_url]
 
 all_doc_attributes[:prince_options][:version]       = options[:prince_version] if options[:prince_version]
 all_doc_attributes[:prince_options][:javascript]    = options[:prince_javascript] if options[:prince_javascript]

--- a/bin/docraptor
+++ b/bin/docraptor
@@ -53,7 +53,7 @@ opt_parser = OptionParser.new do |opts|
     options[:async] = async
   end
 
-  opts.on("--callback_url url", "Set a callback URL to be notified upon success. Defaults to naught") do |callback_url|
+  opts.on("--callback_url url", "Set a callback URL to be notified upon success.") do |callback_url|
     # callback_url can be used for local testing. You need three consoles:
     #   nc -lk 9001                                                       # listen on port 9001 for any data
     #   ngrok http 9001                                                   # setup external URL; port from nc session

--- a/bin/docraptor
+++ b/bin/docraptor
@@ -54,10 +54,6 @@ opt_parser = OptionParser.new do |opts|
   end
 
   opts.on("--callback_url url", "Set a callback URL to be notified upon success.") do |callback_url|
-    # callback_url can be used for local testing. You need three consoles:
-    #   nc -lk 9001                                                       # listen on port 9001 for any data
-    #   ngrok http 9001                                                   # setup external URL; port from nc session
-    #   bin/docraptor content --callback_url "http://1111111111.ngrok.io" # copied url from the ngrok session
     options[:callback_url] = callback_url
   end
 


### PR DESCRIPTION
More control over the async lifecycle for CLI users and testing. Hand tested with ngrok + nc.
